### PR TITLE
Allow passing a closure as an onclick listener in ButtonProps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ console_log = "0.2.0"
 log = "0.4.14"
 
 [dependencies.web-sys]
-features = ["InputEvent", "KeyboardEvent", "Location", "Storage"]
+features = ["InputEvent", "KeyboardEvent", "Location", "Storage", "Event"]
 version = "0.3.55"

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -7,34 +7,16 @@ use sycamore::prelude::*;
 fn main() {
     console_log::init_with_level(Level::Debug);
 
-    let clicked = Signal::new(false);
     let clicked_count = Signal::new(0);
     let disable_all = Signal::new(false);
-    let disable_click = Signal::new(false);
 
-    create_effect({
-        let clicked = clicked.clone();
-        let clicked_count = clicked_count.clone();
-        move || {
-            if *clicked.get() {
-                clicked_count.set(*clicked_count.get() + 1);
-            }
-        }
-    });
+    let handle_click = Box::new(cloned!(clicked_count => move |_| {
+        clicked_count.set(*clicked_count.get() + 1);
+    }));
 
-    create_effect({
-        let disable_click = disable_click.clone();
-        let disable_all = disable_all.clone();
-        move || {
-            if *disable_click.get() {
-                if *disable_all.get() {
-                    disable_all.set(false);
-                } else {
-                    disable_all.set(true)
-                }
-            }
-        }
-    });
+    let disable_click = Box::new(cloned!(disable_all => move |_| {
+        disable_all.set(!*disable_all.get());
+    }));
 
     let enable_disable_label = create_selector(cloned!((disable_all) => move || 
         if *disable_all.get() { "ENABLE ALL".to_string() } else { "DISABLE ALL".to_string() } ));
@@ -46,21 +28,21 @@ fn main() {
 
             Button(ButtonProps::default()
                     .label_from_str("CONTAINED BUTTON")
-                    .on_click(clicked.clone())
+                    .on_click(handle_click.clone())
                     .disabled(disable_all.handle().clone()))
             br()
 
             Button(ButtonProps::default()
                     .label_from_str("OUTLINED BUTTON")
                     .variant(ButtonVariant::Outlined)
-                    .on_click(clicked.clone())
+                    .on_click(handle_click.clone())
                     .disabled(disable_all.handle().clone()))
             br()
 
             Button(ButtonProps::default()
                     .label_from_str("TEXT BUTTON")
                     .variant(ButtonVariant::Text)
-                    .on_click(clicked.clone())
+                    .on_click(handle_click)
                     .disabled(disable_all.handle().clone()))
             br()
 
@@ -83,7 +65,7 @@ fn main() {
             br()br()
             Button(ButtonProps::default()
                     .label(enable_disable_label.clone())
-                    .on_click(disable_click.clone()))
+                    .on_click(disable_click))
             br()
 
         }

--- a/src/button.rs
+++ b/src/button.rs
@@ -1,4 +1,5 @@
 use sycamore::prelude::*;
+use web_sys::Event;
 
 #[derive(Clone)]
 pub enum ButtonVariant {
@@ -7,11 +8,10 @@ pub enum ButtonVariant {
     Text,
 }
 
-#[derive(Clone)]
 pub struct ButtonProps {
     pub variant: ButtonVariant,
     pub label: ReadSignal<String>,
-    pub on_click: Signal<bool>,
+    pub on_click: Box<dyn Fn(Event)>,
     pub disabled: ReadSignal<bool>,
 }
 
@@ -20,7 +20,7 @@ impl Default for ButtonProps {
         Self {
             variant: ButtonVariant::Contained,
             label: Signal::new("".to_string()).handle(),
-            on_click: Signal::new(false),
+            on_click: Box::new(|_| {}),
             disabled: Signal::new(false).handle(),
         }
     }
@@ -38,7 +38,7 @@ impl ButtonProps {
         return self;
     }
 
-    pub fn on_click(mut self, on_click: Signal<bool>) -> Self {
+    pub fn on_click(mut self, on_click: Box<dyn Fn(Event)>) -> Self {
         self.on_click = on_click;
         return self;
     }
@@ -56,10 +56,6 @@ impl ButtonProps {
 
 #[component(Button<G>)]
 pub fn button(props: ButtonProps) -> View<G> {
-    let handle_click = move |_| {
-        (props.on_click.set(true));
-    };
-
     let variant = match props.variant {
         ButtonVariant::Contained => "mdc-button--raised",
         ButtonVariant::Outlined => "mdc-button--outlined",
@@ -69,7 +65,7 @@ pub fn button(props: ButtonProps) -> View<G> {
     let button_classes = format!("mdc-button {} mdc-button--touch", variant);
 
     view! {
-        button(class=button_classes, on:click=handle_click, disabled=*props.disabled.get()) {
+        button(class=button_classes, on:click=props.on_click, disabled=*props.disabled.get()) {
             span(class="mdc-button__ripple")
             span(class="mdc-button__touch")
             span(class="mdc-button__focus-ring")


### PR DESCRIPTION
This PR makes it possible to use Closures in ButtonProps. It does this by allocating the onclick listener on the heap using a Box and then passing it to the `view!` macro. The Box is needed because closures normally have no defined size which is needed sor function parameters and struct members. A Box provides a defined size so we can use it for this purpose.